### PR TITLE
VITIS-9887: XRT support for independent graph compilation and linking

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -850,6 +850,31 @@ get_softkernels(const axlf* top)
   return sks;
 }
 
+std::vector<aieresourcesbin_object>
+get_aieresourcesbin(const axlf* top)
+{
+  std::vector<aieresourcesbin_object> vec;
+  const axlf_section_header *pSection = nullptr;
+
+  for (pSection = ::xclbin::get_axlf_section(top, AIE_RESOURCES_BIN);
+    pSection != nullptr;
+    pSection = ::xclbin::get_axlf_section_next(top, pSection, AIE_RESOURCES_BIN)) {
+      auto begin = reinterpret_cast<const char*>(top) + pSection->m_sectionOffset;
+      auto aieres = reinterpret_cast<const aie_resources_bin*>(begin);
+
+      aieresourcesbin_object obj;
+      obj.mpo_name = std::string(begin + aieres->mpo_name);
+      obj.mpo_version = std::string(begin + aieres->mpo_version);
+      obj.start_col = aieres->m_start_column;
+      obj.num_col = aieres->m_num_columns;
+      obj.size = aieres->m_image_size;
+      obj.ar_buf = const_cast<char*>(begin + aieres->m_image_offset);  // NOLINT
+      vec.emplace_back(std::move(obj));
+  }
+
+  return vec;
+}
+
 aie_partition_obj
 get_aie_partition(const axlf* top)
 {

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -97,6 +97,23 @@ struct softkernel_object
   char *sk_buf;
 };
 
+// struct softresources_object - wrapper for a aie resources object
+//
+// @symbol_name: aie resources symbol name
+// @size: size of aie resources image
+// @start_col: start column
+// @num_col: number of columns
+// @ar_buf: pointer to the aie resourecs buffer
+struct aieresourcesbin_object
+{
+  std::string mpo_name;
+  std::string mpo_version;
+  uint32_t start_col;
+  uint32_t num_col;
+  size_t size;
+  char *ar_buf;
+};
+
 // struct aie_cdo_obj - wrapper for an AIE CDO group object
 //
 // @cdo_name: CDO group name
@@ -319,6 +336,12 @@ get_softkernels(const axlf* top);
 XRT_CORE_COMMON_EXPORT
 aie_partition_obj
 get_aie_partition(const axlf* top);
+
+/**
+ * get_aieresourcesbin() - Get aie resources information.
+ */
+std::vector<aieresourcesbin_object>
+get_aieresourcesbin(const axlf* top);
 
 /**
  * get_kernel_freq() - Get kernel frequency.

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -80,6 +80,14 @@ get_hw_gen(const pt::ptree& aie_meta)
   return aie_meta.get<uint8_t>("aie_metadata.driver_config.hw_gen");
 }
 
+uint32_t
+get_partition_id(const pt::ptree& aie_meta)
+{
+  uint8_t start_col = aie_meta.get<uint8_t>("aie_metadata.driver_config.partition_overlay_start_cols");
+  uint8_t num_col = aie_meta.get<uint8_t>("aie_metadata.driver_config.partition_num_cols");
+  return (num_col << 8U) | (start_col & 0xffU);
+}
+
 adf::aiecompiler_options
 get_aiecompiler_options(const pt::ptree& aie_meta)
 {
@@ -589,6 +597,18 @@ get_hw_gen(const xrt_core::device* device)
   pt::ptree aie_meta;
   read_aie_metadata(data.first, data.second, aie_meta);
   return ::get_hw_gen(aie_meta);
+}
+
+uint32_t
+get_partition_id(const xrt_core::device* device)
+{
+  auto data = device->get_axlf_section(AIE_METADATA);
+  if (!data.first || !data.second)
+    return -1; 
+
+  pt::ptree aie_meta;
+  read_aie_metadata(data.first, data.second, aie_meta);
+  return ::get_partition_id(aie_meta);
 }
 
 }}} // aie, edge, xrt_core

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -194,6 +194,14 @@ uint8_t
 get_hw_gen(const xrt_core::device* device);
 
 /**
+ * get_partition_id - calculate aie_partition_id from xclbin AIE metadata
+ *
+ * @device: device with loaded meta data
+ */
+uint32_t
+get_partition_id(const xrt_core::device* device);
+
+/**
  * get_trace_gmios() - get trace gmio data from xclbin AIE metadata
  *
  * @device: device with loaded meta data

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -215,6 +215,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	int slot_id = 0;
 	uint32_t qos = 0;
 	uint8_t hw_gen = axlf_obj->hw_gen;
+	uint32_t part_id = axlf_obj->partition_id;
 
 	/* Download the XCLBIN from user space to kernel space and validate */
 	if (copy_from_user(&axlf_head, axlf_obj->za_xclbin_ptr,
@@ -403,7 +404,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	zocl_init_mem(zdev, slot);
 
 	/* Createing AIE Partition */
-	zocl_create_aie(zdev, axlf, aie_res, hw_gen);
+	zocl_create_aie(zdev, axlf, aie_res, hw_gen, part_id);
 
 	/*
 	 * Remember xclbin_uuid for opencontext.

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -266,7 +266,7 @@ void zocl_clear_mem(struct drm_zocl_dev *zdev);
 void zocl_clear_mem_slot(struct drm_zocl_dev *zdev, u32 slot_idx);
 int zocl_cleanup_aie(struct drm_zocl_dev *zdev);
 int zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf,
-		void *aie_res, uint8_t hw_gen);
+		void *aie_res, uint8_t hw_gen, uint32_t part_id);
 void zocl_destroy_aie(struct drm_zocl_dev *zdev);
 int zocl_aie_request_part_fd(struct drm_zocl_dev *zdev, void *data);
 int zocl_aie_reset(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -122,6 +122,12 @@ struct aie_metadata {
 	void *data;
 };
 
+struct aie_res_bin {
+	uint32_t start_col;
+	uint32_t num_col;
+	void *data;
+};
+
 struct drm_zocl_slot {
 	u32			 slot_idx;
 	u32			 slot_type;
@@ -176,6 +182,8 @@ struct drm_zocl_dev {
 	struct zocl_cu_subdev	 cu_subdev;
 	struct platform_device	*cu_intc;
 	struct kds_sched	 kds;
+
+	struct aie_res_bin 	*res_info;
 
 	/*
 	 * This RW lock is to protect the sysfs nodes exported

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_ps_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_ps_xclbin.c
@@ -304,6 +304,7 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data, uint32_t slot_i
 	void *aie_res = 0;
 	struct device_node *aienode = NULL;
 	uint8_t hw_gen = 1;
+	uint32_t part_id = 1;
 	struct aie_metadata      aie_data = { 0 };
 	uint64_t size = 0;
 
@@ -369,7 +370,7 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data, uint32_t slot_i
 	// Cache full xclbin
 	//last argument represents aie generation. 1. aie, 2. aie-ml ...
 	DRM_INFO("AIE Device set to gen %d", hw_gen);
-	zocl_create_aie(zdev, axlf, aie_res, hw_gen);
+	zocl_create_aie(zdev, axlf, aie_res, hw_gen, part_id);
 
 
 	ret = zocl_kernel_cache_xclbin(zdev, slot, axlf);

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -437,6 +437,7 @@ struct drm_zocl_kds {
  * @za_kernels:	pointer of argument array
  * @za_slot_id:	xclbin slot
  * @hw_gen:	aie generation
+ * @partition_id: aie partition id
  **/
 struct drm_zocl_axlf {
 	struct axlf		*za_xclbin_ptr;
@@ -447,6 +448,7 @@ struct drm_zocl_axlf {
 	char			*za_dtbo_path;
 	uint32_t		za_dtbo_path_len;
 	uint8_t		        hw_gen;
+	uint32_t		partition_id;
 	struct drm_zocl_kds	kds_cfg;
 };
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -734,6 +734,7 @@ xclLoadAxlf(const axlf *buffer)
 
     /* Get the AIE_METADATA and get the hw_gen information */
     uint8_t hw_gen = xrt_core::edge::aie::get_hw_gen(mCoreDevice.get());
+    uint8_t partition_id = xrt_core::edge::aie::get_partition_id(mCoreDevice.get());
 
     drm_zocl_axlf axlf_obj = {
       .za_xclbin_ptr = const_cast<axlf *>(buffer),
@@ -744,6 +745,7 @@ xclLoadAxlf(const axlf *buffer)
       .za_dtbo_path = const_cast<char *>(dtbo_path.c_str()),
       .za_dtbo_path_len = static_cast<unsigned int>(dtbo_path.length()),
       .hw_gen = hw_gen,
+      .partition_id = partition_id,
     };
 
   axlf_obj.kds_cfg.polling = xrt_core::config::get_ert_polling();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/VITIS-9887
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Iterating over the new section- AIE_RESOURCES_BIN for each entry and calling the aie driver api to send multiple aie resource information.
Also, added get_partition_id function to support sub partition (not complete array). (The AIE driver has to fix following CR for driver support: https://jira.xilinx.com/browse/CR-1185272
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
